### PR TITLE
chore(ci): cap upload-artifact retention to 1 day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
           
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
       if: always()
       with:
         name: test-results
@@ -157,6 +159,8 @@ jobs:
           
     - name: Upload Release Artifact
       uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
       with:
         name: CCMate-Release
         path: build/*.dmg


### PR DESCRIPTION
Cap retention to 1 day to prevent GHA storage quota from filling.